### PR TITLE
Update os and docile dependencies

### DIFF
--- a/ox-builder.gemspec
+++ b/ox-builder.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'benchmark-ips'
   gem.add_development_dependency 'builder'
 
-  gem.add_dependency 'ox', ['~> 2.8.0']
-  gem.add_dependency 'docile', ['~> 1.3.0]
+  gem.add_dependency 'ox', ['>= 2.3.0']
+  gem.add_dependency 'docile', ['>= 1.1.5']
 end

--- a/ox-builder.gemspec
+++ b/ox-builder.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'benchmark-ips'
   gem.add_development_dependency 'builder'
 
-  gem.add_dependency 'ox', ['~> 2.3.0']
-  gem.add_dependency 'docile', ['~> 1.1.5']
+  gem.add_dependency 'ox', ['~> 2.8.0']
+  gem.add_dependency 'docile', ['~> 1.3.0]
 end


### PR DESCRIPTION
The ox dependency has kept pace with Ruby development over the last few years and with this change os-builder can work against modern Ruby versions